### PR TITLE
Fix naming convention

### DIFF
--- a/prompts/poem/020_user_prompt.md
+++ b/prompts/poem/020_user_prompt.md
@@ -1,10 +1,12 @@
 My project uses the following languages:
 
-{{project.languages}}
+{{#linguist}}
+* {{ language }}
+{{/linguist}}
 
 My project has the following files:
 
-{{project.files}}
+{{project-facts.files}}
 
 Write me a poem in the style of Supa Hot Fire.
 

--- a/prompts/poem/README.md
+++ b/prompts/poem/README.md
@@ -1,6 +1,7 @@
 ---
 extractors:
   - name: project-facts
+  - name: linguist
 functions:
   - name: write_files
 ---


### PR DESCRIPTION
@ColinMcNeil

I would use the linguist extractor since it's easier to understand where the data is coming from if we have multiple extractors.

Also `project` is no longer a top-level key since all of top-level keys are now the names of the extractor functions.