### PR TITLE
Add socket server to the extension

### DIFF
--- a/docs/content/tools/docs/claude-desktop.md
+++ b/docs/content/tools/docs/claude-desktop.md
@@ -12,7 +12,7 @@ Use our Docker Desktop extension to automatically register and use our tools.
 
 # Manual Setup
 
-Enable mcp_run in your claude_desktop_config.json file using the following snippet.  See the [quickstart for Claude Desktop Users](https://modelcontextprotocol.io/quickstart/user) for more details.
+Enable mcp_docker in your claude_desktop_config.json file using the following snippet.  See the [quickstart for Claude Desktop Users](https://modelcontextprotocol.io/quickstart/user) for more details.
 
 ```json
 
@@ -21,15 +21,10 @@ Enable mcp_run in your claude_desktop_config.json file using the following snipp
     "mcp_docker": {
       "command": "docker",
       "args": [
-        "run", "--rm", "-i", "--pull", "always",
-        "-v", "/var/run/docker.sock:/var/run/docker.sock",
-        "--mount", "type=volume,source=docker-prompts,target=/prompts",
-        "mcp/docker:latest",
-        "serve",
-        "--mcp",
-        "--register", "github:docker/labs-ai-tools-for-devs?path=prompts/bootstrap.md"
+    	"run", "-i", "--rm", "alpine/socat", "STDIO", "TCP:host.docker.internal:8811"
       ]
     }
+  }
 }
 ```
 

--- a/docs/content/tools/quickstart.md
+++ b/docs/content/tools/quickstart.md
@@ -19,7 +19,7 @@ or manually [configure claude desktop](../docs/claude-desktop) to use the `mcp/r
 
 Restarting desktop should be a one-time activity. However, Claude
 Desktop does not support the `tools/list_changed` notification so we
-currently have to restart desktop more less continuously. Fire up those keybinds :)
+currently have to restart desktop more less continuously. Use `alt + r` to restart Claude Desktop.
 
 ### Try a prompt
 

--- a/docs/content/tools/quickstsart_cursor.md
+++ b/docs/content/tools/quickstsart_cursor.md
@@ -16,7 +16,7 @@ weight: 3
 2. Choose `Command` mode and then copy and paste the following string into the field labeled "Command".
 
    ```
-   docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock --mount type=volume,source=docker-prompts,target=/prompts mcp/docker:latest serve --mcp --register github:docker/labs-ai-tools-for-devs?path=prompts/bootstrap.md
+   docker run --rm -i alpine/socat:latest STDIO TCP:host.docker.internal:8811
    ```
 
    After entering this command, the server will start and you should see a list of available tools.

--- a/src/extension/docker-compose.yaml
+++ b/src/extension/docker-compose.yaml
@@ -1,4 +1,18 @@
 services:
-  labs-ai-tools-for-devs:
-    image: ${DESKTOP_PLUGIN_IMAGE}
-
+  mcp_docker:
+    image: mcp/docker
+    ports:
+      - 8811:8811
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "docker-prompts:/prompts"
+    command:
+      - serve
+      - --mcp
+      - --port
+      - "8811"
+      - --register
+      - github:docker/labs-ai-tools-for-devs?path=prompts/bootstrap.md
+volumes:
+  docker-prompts:
+    name: docker-prompts

--- a/src/extension/ui/src/components/ClaudeConfigSyncStatus.tsx
+++ b/src/extension/ui/src/components/ClaudeConfigSyncStatus.tsx
@@ -217,3 +217,4 @@ export const ClaudeConfigSyncStatus = ({ client, setHasConfig }: { client: v1.Do
         </Button>
     </Badge >
 }
+

--- a/src/extension/ui/src/components/ClaudeConfigSyncStatus.tsx
+++ b/src/extension/ui/src/components/ClaudeConfigSyncStatus.tsx
@@ -8,20 +8,12 @@ import { ExecResult } from "@docker/extension-api-client-types/dist/v1";
 const DOCKER_MCP_CONFIG = {
     "command": "docker",
     "args": [
-        "run",
-        "--rm",
-        "-i",
-        "--pull",
-        "always",
-        "-v",
-        "/var/run/docker.sock:/var/run/docker.sock",
-        "--mount",
-        "type=volume,source=docker-prompts,target=/prompts",
-        "mcp/docker:latest",
-        "serve",
-        "--mcp",
-        "--register",
-        "github:docker/labs-ai-tools-for-devs?path=prompts/bootstrap.md"
+      	"run", 
+	"-i", 
+	"--rm", 
+	"alpine/socat", 
+	"STDIO", 
+	"TCP:host.docker.internal:8811"
     ]
 }
 

--- a/src/extension/ui/src/components/Gordon.tsx
+++ b/src/extension/ui/src/components/Gordon.tsx
@@ -10,15 +10,9 @@ import { tryRunImageSync, writeFilesToHost } from '../FileWatcher';
 const DOCKER_MCP_CONFIG_YML = {
     services: {
         mcp_docker: {
-            image: "mcp/docker",
-            command: ["serve", "--mcp", "--register", "github:docker/labs-ai-tools-for-devs?path=prompts/bootstrap.md"],
-            volumes: ["/var/run/docker.sock:/var/run/docker.sock", "docker-prompts:/prompts"],
-            "x-mcp-autoremove": true,
-        }
-    },
-    volumes: {
-        docker_prompts: {
-            external: false
+            image: "alpine/socat",
+            command: ["STDIO", "TCP:host.docker.internal:8811"],
+            "x-mcp-autoremove": true
         }
     }
 }
@@ -55,10 +49,6 @@ const Gordon: React.FC<{ client: v1.DockerDesktopClient }> = ({ client }) => {
                             services: {
                                 ...current_config_yaml.services,
                                 mcp_docker: DOCKER_MCP_CONFIG_YML.services.mcp_docker
-                            },
-                            volumes: {
-                                ...current_config_yaml.volumes,
-                                docker_prompts: DOCKER_MCP_CONFIG_YML.volumes.docker_prompts
                             }
                         }
                         await writeFilesToHost(client, [{ path: 'gordon-mcp.yml', content: stringify(new_config) }], [{ source: path, target: '/project' }], '/project')


### PR DESCRIPTION
Updates the extension to start up the socket mcp server on port 8811.
This server can be shared by any number of local mcp clients.

Since the mcp stdio clients can now just be simple socat programs, claude desktop and Gordon can just bind to this one shared server.

Integrating this into 0.9.1 is a somewhat large change in htat existing claude desktop configs need to be updated to start using socat.  
