### PR TITLE
Smaller image

### DIFF
--- a/functions/github-mcp-server/Dockerfile
+++ b/functions/github-mcp-server/Dockerfile
@@ -1,10 +1,6 @@
-FROM ghcr.io/github/github-mcp-server as github
-
-FROM debian:bookworm-slim
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
 
 WORKDIR /server
-
-COPY --from=github /server/github-mcp-server .
-
+COPY --from=ghcr.io/github/github-mcp-server  /server/github-mcp-server .
 ENTRYPOINT ["/server/github-mcp-server", "stdio"]
-


### PR DESCRIPTION
With a debian base, the image is 147Mb
With an alpine base, the image is 25Mb

All we seem to need here is a shell and certificates.