### PR TITLE
Fix the extension make ui-run command

### DIFF
--- a/src/extension/Makefile
+++ b/src/extension/Makefile
@@ -42,4 +42,4 @@ debug-reset: # Reset Chrome-dev tools
 debug-ui: # Set UI hot reload
 	docker extension dev ui-source $(IMAGE):$(TAG) http://localhost:3000
 ui-run:
-	cd ui && npm start
+	cd ui && npm run dev


### PR DESCRIPTION
[As noted in the readme](https://github.com/docker/labs-ai-tools-for-devs/tree/main/src/extension#frontend-development) and the `src/extension/ui/package.json` the command to start the ui is `npm run dev`