### PR TITLE
Update tab name

### DIFF
--- a/src/extension/ui/src/components/CatalogGrid.tsx
+++ b/src/extension/ui/src/components/CatalogGrid.tsx
@@ -124,7 +124,7 @@ export const CatalogGrid: React.FC<CatalogGridProps> = ({
                 </Alert>}
                 <Box sx={{ position: 'sticky', top: 0, zIndex: 1000, backgroundColor: 'background.default' }}>
                     <Tabs value={tab} onChange={(_, newValue) => setTab(newValue)} sx={CATALOG_LAYOUT_SX}>
-                        <Tab label="Tools" />
+                        <Tab label="Servers" />
                         <Tab label={<Badge variant='dot' invisible={!noConfiguredClients} badgeContent={"TEST"} color="error">
                             Clients
                         </Badge>} />


### PR DESCRIPTION
The "Tools" tab actually shows MCP Servers which themselves have tools. Let's try be more precise and list that tab as "Servers". I've also touched the description a bit.

Before
<img width="493" alt="image" src="https://github.com/user-attachments/assets/b6e932b5-e510-4dc1-8504-1ed4759faa30" />

After
<img width="509" alt="image" src="https://github.com/user-attachments/assets/199f2caa-eca6-49dc-acdd-d91b23dd5797" />

