### PR TITLE
User smaller, pinned `busybox` image

### DIFF
--- a/src/extension/ui/src/Constants.ts
+++ b/src/extension/ui/src/Constants.ts
@@ -21,3 +21,8 @@ export const CATALOG_LAYOUT_SX = {
 
 export const ASSIGNED_SECRET_PLACEHOLDER = "********";
 export const UNASSIGNED_SECRET_PLACEHOLDER = "UNASSIGNED";
+
+export const BUSYBOX = 'busybox@sha256:37f7b378a29ceb4c551b1b5582e27747b855bbfaa73fa11914fe0df028dc581f';
+
+// Filenames in docker-prompts volume
+export const REGISTRY_YAML = 'registry.yaml'

--- a/src/extension/ui/src/Registry.ts
+++ b/src/extension/ui/src/Registry.ts
@@ -1,6 +1,7 @@
 import { v1 } from "@docker/extension-api-client-types";
 import { parse, stringify } from "yaml";
-import { readFileInPromptsVolume, writeFileToPromptsVolume } from "./FileUtils";
+import { REGISTRY_YAML } from "./Constants";
+import { readFileInPromptsVolume, writeToPromptsVolume } from "./FileUtils";
 import { mergeDeep } from "./MergeDeep";
 import { ParsedParameters } from "./types/config";
 
@@ -19,7 +20,7 @@ export const getRegistry = async (client: v1.DockerDesktopClient) => {
     const writeRegistryIfNotExists = async () => {
         const registry = await readFileInPromptsVolume(client, 'registry.yaml')
         if (!registry) {
-            await writeFileToPromptsVolume(client, JSON.stringify({ files: [{ path: 'registry.yaml', content: 'registry: {}' }] }))
+            await writeToPromptsVolume(client, REGISTRY_YAML, 'registry: {}')
         }
     }
     try {
@@ -43,7 +44,7 @@ export const getStoredConfig = async (client: v1.DockerDesktopClient) => {
     const writeConfigIfNotExists = async () => {
         const config = await readFileInPromptsVolume(client, 'config.yaml')
         if (!config) {
-            await writeFileToPromptsVolume(client, JSON.stringify({ files: [{ path: 'config.yaml', content: '{}' }] }))
+            await writeToPromptsVolume(client, 'config.yaml', '{}')
         }
     }
     try {
@@ -79,7 +80,7 @@ export const syncConfigWithRegistry = async (client: v1.DockerDesktopClient, reg
     }
     const newConfigString = JSON.stringify(config)
     if (oldConfigString !== newConfigString) {
-        await writeFileToPromptsVolume(client, JSON.stringify({ files: [{ path: 'config.yaml', content: stringify(config) }] }))
+        await writeToPromptsVolume(client, 'config.yaml', stringify(config))
     }
     return config
 }
@@ -105,7 +106,7 @@ export const syncRegistryWithConfig = async (client: v1.DockerDesktopClient, reg
     }
     const newRegString = JSON.stringify(registry)
     if (oldRegString !== newRegString) {
-        await writeFileToPromptsVolume(client, JSON.stringify({ files: [{ path: 'registry.yaml', content: stringify({ registry }) }] }))
+        await writeToPromptsVolume(client, REGISTRY_YAML, stringify({ registry }))
     }
     return registry
 }

--- a/src/extension/ui/src/components/LoadingState.tsx
+++ b/src/extension/ui/src/components/LoadingState.tsx
@@ -137,62 +137,6 @@ const LoadingState: React.FC<LoadingStateProps> = ({ appProps }) => {
                             variant="determinate"
                             value={progress}
                         />
-
-                        {imagesLoading && imageStates && (
-                            <Box
-                                sx={{
-                                    mt: 2,
-                                    p: 2,
-                                    width: '100%',
-                                    backgroundColor: 'rgba(0, 0, 0, 0.03)',
-                                    borderRadius: 1,
-                                }}
-                            >
-                                <Typography variant="subtitle2" fontWeight="medium" gutterBottom>
-                                    Docker Images
-                                </Typography>
-
-                                <Stack spacing={1.5} mt={1}>
-                                    {/* Type assertion for imageStates */}
-                                    {Object.entries(imageStates as Record<string, ImageState>).map(([imageName, state]) => (
-                                        <Box
-                                            key={imageName}
-                                            sx={{
-                                                display: 'flex',
-                                                justifyContent: 'space-between',
-                                                alignItems: 'center',
-                                                p: 1,
-                                                borderRadius: 1,
-                                                backgroundColor: 'background.paper',
-                                            }}
-                                        >
-                                            <Typography variant="body2" fontWeight="medium">{imageName}</Typography>
-                                            <Box
-                                                sx={{
-                                                    display: 'flex',
-                                                    alignItems: 'center',
-                                                    gap: 1,
-                                                }}
-                                            >
-                                                {state.status === 'loading' && (
-                                                    <CircularProgress size={14} thickness={4} />
-                                                )}
-                                                <Typography
-                                                    variant="body2"
-                                                    sx={{
-                                                        color: getStatusColor(state.status),
-                                                        fontWeight: 'medium',
-                                                        textTransform: 'capitalize'
-                                                    }}
-                                                >
-                                                    {state.status}
-                                                </Typography>
-                                            </Box>
-                                        </Box>
-                                    ))}
-                                </Stack>
-                            </Box>
-                        )}
                     </Stack>
                 </Paper>
             </Box>

--- a/src/extension/ui/src/queries/useRequiredImages.ts
+++ b/src/extension/ui/src/queries/useRequiredImages.ts
@@ -1,12 +1,10 @@
 import { v1 } from "@docker/extension-api-client-types";
-import { useQuery } from '@tanstack/react-query';
 import { ExecResult } from '@docker/extension-api-client-types/dist/v0';
+import { useQuery } from '@tanstack/react-query';
+import { BUSYBOX } from "../Constants";
 
 // List of required images for the extension
-const REQUIRED_IMAGES = [
-    'vonwig/function_write_files:latest',
-    'alpine:latest'
-];
+const REQUIRED_IMAGES = [BUSYBOX];
 
 // Image loading state interface
 interface ImageState {


### PR DESCRIPTION
+ Use `busybox` as much as possible because it's only 6Mb. `alpine` is 25Mb and `vonwig/function_write_files` is 64Mb.
+ Use an image with a digest to avoid someone replacing the image we use with something malicious with the same name.
+ Use a more robust base64 escaping strategy. It would have been even better to pass the file's content on stdin but the extension's docker api doesn't support that.
+ Remove a lot of the duplication.
+ Make it work even when Claude's existing config is not valid.


