### PR TITLE
Fix MCP server config overwriting

### DIFF
--- a/src/extension/ui/src/queries/useConfig.ts
+++ b/src/extension/ui/src/queries/useConfig.ts
@@ -52,7 +52,6 @@ export function useConfig(client: v1.DockerDesktopClient) {
       newConfig: { [key: string]: any };
     }) => {
       try {
-        // Use the ref which contains the pre-optimistic update state
         const updatedConfig = {  ...((queryClient.getQueryData(["config"]) as Record<string, any>) ||
           {}), [itemName]: newConfig };
 

--- a/src/extension/ui/src/queries/useConfig.ts
+++ b/src/extension/ui/src/queries/useConfig.ts
@@ -21,7 +21,6 @@ export const getTemplateForItem = (
 
 export function useConfig(client: v1.DockerDesktopClient) {
   const queryClient = useQueryClient();
-  const configRef = useRef<any>(null);
 
   const {
     data: config = undefined,
@@ -33,8 +32,6 @@ export function useConfig(client: v1.DockerDesktopClient) {
       try {
         const response = await getStoredConfig(client);
         const result = response || {};
-        // Store a deep copy of the config in the ref
-        configRef.current = JSON.parse(JSON.stringify(result));
         return result;
       } catch (error) {
         client.desktopUI.toast.error("Failed to get stored config: " + error);
@@ -56,13 +53,12 @@ export function useConfig(client: v1.DockerDesktopClient) {
     }) => {
       try {
         // Use the ref which contains the pre-optimistic update state
-        const currentStoredConfig = { ...(configRef.current || {}) };
-        const updatedConfig = { ...currentStoredConfig, [itemName]: newConfig };
+        const updatedConfig = {  ...((queryClient.getQueryData(["config"]) as Record<string, any>) ||
+          {}), [itemName]: newConfig };
 
         await writeToPromptsVolume(client, 'config.yaml', stringify(updatedConfig));
 
         const updatedConfigRef = JSON.parse(JSON.stringify(updatedConfig));
-        configRef.current = updatedConfigRef;
         return { itemName, updatedConfig: updatedConfigRef };
       } catch (error) {
         client.desktopUI.toast.error("Failed to update config: " + error);


### PR DESCRIPTION
Bug: Imagine you want to configure two MCP servers (A and B) through the UI. You configure MCP server A, and you go to configure MCP server B. When you save the configuration of server B, the configuration of server A is gone. 

Reason: This was caused because we have two references of config data. One in queryClient and one in a react useRef hook which we need to manage manually. We do update the useRef when we fetch the config but we don't when we mutate it. Meaning we would use an older state of the config when we go to update more server configs. You might think that we refetch the config (and update the useRef) every time we have a component that uses the `useConfig` hook but that's not the case. The fetch config query has a stale time of 30 seconds so it wouldn't always refetch.


How to test: 

1. Update a MCP server's config
2. `docker run --rm -v docker-prompts:/docker-prompts --workdir /docker-prompts alpine:latest sh -c "cat config.yaml"`
3. You should see your updated config
4. Update another MCP server's config
5. `docker run --rm -v docker-prompts:/docker-prompts --workdir /docker-prompts alpine:latest sh -c "cat config.yaml"`
6. You should see both MCP server configs


PS. It is unclear to me why we needed the useRef in the first place so I removed it. I think we can achieve what we want with react query only.