### PR TITLE
Add "derive" command

### DIFF
--- a/src/extension/host-binary/api/schemas/secrets.yaml
+++ b/src/extension/host-binary/api/schemas/secrets.yaml
@@ -56,7 +56,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StoredSecret'
+                $ref: '#/components/schemas/Secret'
         '404':
           description: secret not found
     delete:

--- a/src/extension/host-binary/pkg/client/client.go
+++ b/src/extension/host-binary/pkg/client/client.go
@@ -13,7 +13,7 @@ type ApiClient interface {
 	// GetPolicy retrieves a policy
 	GetPolicy(ctx context.Context, policy string) (secretsapi.Policy, error)
 	// GetSecret checks if a secret exists
-	GetSecret(ctx context.Context, secret string) (secretsapi.StoredSecret, error)
+	GetSecret(ctx context.Context, secret string) (secretsapi.Secret, error)
 	// ListPolicies lists all policies
 	ListPolicies(ctx context.Context) ([]secretsapi.Policy, error)
 	// ListSecrets lists all secrets
@@ -56,11 +56,11 @@ func (d apiClientImpl) ListSecrets(ctx context.Context) ([]secretsapi.StoredSecr
 	return res, err
 }
 
-func (d apiClientImpl) GetSecret(ctx context.Context, secret string) (secretsapi.StoredSecret, error) {
+func (d apiClientImpl) GetSecret(ctx context.Context, secret string) (secretsapi.Secret, error) {
 	apiReq := d.SecretsApi.GetJfsSecret(ctx, secret)
 	res, _, err := apiReq.Execute()
 	if err != nil {
-		return secretsapi.StoredSecret{}, err
+		return secretsapi.Secret{}, err
 	}
 	return *res, nil
 }

--- a/src/extension/host-binary/pkg/client/client.go
+++ b/src/extension/host-binary/pkg/client/client.go
@@ -38,7 +38,8 @@ func NewApiClient(socketPath string) ApiClient {
 
 func (d apiClientImpl) SetSecret(ctx context.Context, s secretsapi.Secret) error {
 	apiReq := d.SecretsApi.SetJfsSecret(ctx)
-	req := secretsapi.NewSecret(s.Name, s.Value, s.Policies)
+	req := secretsapi.NewSecret(s.Name, s.Value)
+	req.SetPolicies(s.Policies)
 	_, err := apiReq.Secret(*req).Execute()
 	return err
 }

--- a/src/extension/host-binary/pkg/generated/go/client/secrets/api/openapi.yaml
+++ b/src/extension/host-binary/pkg/generated/go/client/secrets/api/openapi.yaml
@@ -77,7 +77,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StoredSecret'
+                $ref: '#/components/schemas/Secret'
           description: success
         "404":
           description: secret not found

--- a/src/extension/host-binary/pkg/generated/go/client/secrets/api_secrets.go
+++ b/src/extension/host-binary/pkg/generated/go/client/secrets/api_secrets.go
@@ -68,8 +68,8 @@ type SecretsApi interface {
 	GetJfsSecret(ctx context.Context, secret string) ApiGetJfsSecretRequest
 
 	// GetJfsSecretExecute executes the request
-	//  @return StoredSecret
-	GetJfsSecretExecute(r ApiGetJfsSecretRequest) (*StoredSecret, *http.Response, error)
+	//  @return Secret
+	GetJfsSecretExecute(r ApiGetJfsSecretRequest) (*Secret, *http.Response, error)
 
 	/*
 		ListJfsPolicies lists all policies
@@ -409,7 +409,7 @@ type ApiGetJfsSecretRequest struct {
 	secret     string
 }
 
-func (r ApiGetJfsSecretRequest) Execute() (*StoredSecret, *http.Response, error) {
+func (r ApiGetJfsSecretRequest) Execute() (*Secret, *http.Response, error) {
 	return r.ApiService.GetJfsSecretExecute(r)
 }
 
@@ -430,13 +430,13 @@ func (a *SecretsApiService) GetJfsSecret(ctx context.Context, secret string) Api
 
 // Execute executes the request
 //
-//	@return StoredSecret
-func (a *SecretsApiService) GetJfsSecretExecute(r ApiGetJfsSecretRequest) (*StoredSecret, *http.Response, error) {
+//	@return Secret
+func (a *SecretsApiService) GetJfsSecretExecute(r ApiGetJfsSecretRequest) (*Secret, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *StoredSecret
+		localVarReturnValue *Secret
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SecretsApiService.GetJfsSecret")

--- a/src/extension/host-binary/pkg/generated/go/client/secrets/docs/SecretsApi.md
+++ b/src/extension/host-binary/pkg/generated/go/client/secrets/docs/SecretsApi.md
@@ -217,7 +217,7 @@ No authorization required
 
 ## GetJfsSecret
 
-> StoredSecret GetJfsSecret(ctx, secret).Execute()
+> Secret GetJfsSecret(ctx, secret).Execute()
 
 checks if a secret exists
 
@@ -243,7 +243,7 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `SecretsApi.GetJfsSecret``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
-    // response from `GetJfsSecret`: StoredSecret
+    // response from `GetJfsSecret`: Secret
     fmt.Fprintf(os.Stdout, "Response from `SecretsApi.GetJfsSecret`: %v\n", resp)
 }
 ```
@@ -267,7 +267,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**StoredSecret**](StoredSecret.md)
+[**Secret**](Secret.md)
 
 ### Authorization
 

--- a/src/extension/host-binary/pkg/generated/go/client/secrets/html/index.html
+++ b/src/extension/host-binary/pkg/generated/go/client/secrets/html/index.html
@@ -1998,7 +1998,7 @@ public class SecretsApiExample {
         String secret = secret_example; // String | 
 
         try {
-            StoredSecret result = apiInstance.getJfsSecret(secret);
+            Secret result = apiInstance.getJfsSecret(secret);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling SecretsApi#getJfsSecret");
@@ -2018,7 +2018,7 @@ public class SecretsApiExample {
         String secret = secret_example; // String | 
 
         try {
-            StoredSecret result = apiInstance.getJfsSecret(secret);
+            Secret result = apiInstance.getJfsSecret(secret);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling SecretsApi#getJfsSecret");
@@ -2040,7 +2040,7 @@ String *secret = secret_example; //  (default to null)
 
 // checks if a secret exists
 [apiInstance getJfsSecretWith:secret
-              completionHandler: ^(StoredSecret output, NSError* error) {
+              completionHandler: ^(Secret output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
     }
@@ -2092,7 +2092,7 @@ namespace Example
 
             try {
                 // checks if a secret exists
-                StoredSecret result = apiInstance.getJfsSecret(secret);
+                Secret result = apiInstance.getJfsSecret(secret);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling SecretsApi.getJfsSecret: " + e.Message );
@@ -2247,7 +2247,7 @@ pub fn main() {
   "content" : {
     "application/json" : {
       "schema" : {
-        "$ref" : "#/components/schemas/StoredSecret"
+        "$ref" : "#/components/schemas/Secret"
       }
     }
   }

--- a/src/extension/host-binary/pkg/generated/go/client/secrets/model_secret.go
+++ b/src/extension/host-binary/pkg/generated/go/client/secrets/model_secret.go
@@ -28,11 +28,10 @@ type Secret struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSecret(name string, value string, policies []string) *Secret {
+func NewSecret(name string, value string) *Secret {
 	this := Secret{}
 	this.Name = name
 	this.Value = value
-	this.Policies = policies
 	return &this
 }
 


### PR DESCRIPTION
The OAuth flow ends with adding a secret named after the OAuth app into the secret management. 

This commands allows to derive/fork a new secret from that OAuth access token with correct MCP policy.