### PR TITLE
Remove configuration causing old data to stick around in the UI

### DIFF
--- a/src/extension/ui/src/main.tsx
+++ b/src/extension/ui/src/main.tsx
@@ -11,12 +11,6 @@ import { App } from './App';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // Keep data in cache for 5 minutes
-      gcTime: 5 * 60 * 1000,
-      // Treat data as fresh for 30 seconds
-      staleTime: 30 * 1000,
-      // Don't refetch on window focus by default
-      refetchOnWindowFocus: false,
       // Retry failed queries 3 times
       retry: 3
     }


### PR DESCRIPTION
A combination of `staleTime` `gcTime` keeps old data lying around in the UI in the event that anything changes outside the app. Additionally, `refetchOnWindowFocus` breaks user expectation to see new information when they switch back to the app.