### PR TITLE
Fix additional URL shown at the bottom of the extension card

### DIFF
--- a/src/extension/Dockerfile
+++ b/src/extension/Dockerfile
@@ -42,7 +42,7 @@ LABEL org.opencontainers.image.title="Docker MCP Toolkit" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/docker/labs-ai-tools-for-devs/main/src/extension/ui/src/assets/extension-icon.png" \
     com.docker.extension.detailed-description="Browse and connect Dockerized MCP servers to your favorite MCP clients" \
     com.docker.extension.publisher-url="https://www.docker.com/" \
-    com.docker.extension.additional-urls="https://hub.docker.com/catalogs/mcp" \
+    com.docker.extension.additional-urls="[{\"title\":\"MCP Catalog\",\"url\":\"https://hub.docker.com/catalogs/mcp\"}]" \
     com.docker.extension.categories="utility-tools" \
     com.docker.extension.changelog="Added MCP catalog"
 


### PR DESCRIPTION
We noticed in some Desktop logs that the additional URL for this extension was not parsed correctly. 
Here's a fix (additonal_url must be a json array with a title for each URL, )
`docker extension validate docker/labs-ai-tools-for-devs:1.0.1` shows the error, this specific validation was probably not in place when the extension was added in the marketplace initially. 

Now the "MCP Catalog" link appears below the extension screenshots: 

<img width="1337" alt="Screenshot 2025-06-17 at 17 18 00" src="https://github.com/user-attachments/assets/be7421f1-5290-4e15-960a-57982c8a935d" />
