### PR TITLE
Remove org-image-score badge from generated MCP readmes

### DIFF
--- a/prompts/mcp/readmes/302_sandbox.md
+++ b/prompts/mcp/readmes/302_sandbox.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/302ai/302_sandbox_mcp
 **Dockerfile**|https://github.com/302ai/302_sandbox_mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/302_sandbox)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/302_sandbox --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/armor-crypto.md
+++ b/prompts/mcp/readmes/armor-crypto.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/armorwallet/armor-crypto-mcp
 **Dockerfile**|https://github.com/armorwallet/armor-crypto-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/armor-crypto)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/armor-crypto --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|GNU General Public License v3.0
 

--- a/prompts/mcp/readmes/astra-db.md
+++ b/prompts/mcp/readmes/astra-db.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/datastax/astra-db-mcp
 **Dockerfile**|https://github.com/datastax/astra-db-mcp/blob/refs/pull/14/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/astra-db)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/astra-db --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/atlas-docs.md
+++ b/prompts/mcp/readmes/atlas-docs.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/CartographAI/atlas-docs-mcp
 **Dockerfile**|https://github.com/CartographAI/atlas-docs-mcp/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/atlas-docs)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/atlas-docs --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/atlassian.md
+++ b/prompts/mcp/readmes/atlassian.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/sooperset/mcp-atlassian
 **Dockerfile**|https://github.com/sooperset/mcp-atlassian/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/atlassian)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/atlassian --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/audiense-insights.md
+++ b/prompts/mcp/readmes/audiense-insights.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/AudienseCo/mcp-audiense-insights
 **Dockerfile**|https://github.com/AudienseCo/mcp-audiense-insights/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/audiense-insights)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/audiense-insights --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/aws-cdk-mcp-server.md
+++ b/prompts/mcp/readmes/aws-cdk-mcp-server.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/awslabs/mcp
 **Dockerfile**|https://github.com/awslabs/mcp/blob/main/src/cdk-mcp-server/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/aws-cdk-mcp-server)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/aws-cdk-mcp-server --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/aws-core-mcp-server.md
+++ b/prompts/mcp/readmes/aws-core-mcp-server.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/awslabs/mcp
 **Dockerfile**|https://github.com/awslabs/mcp/blob/main/src/core-mcp-server/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/aws-core-mcp-server)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/aws-core-mcp-server --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/aws-diagram.md
+++ b/prompts/mcp/readmes/aws-diagram.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/awslabs/mcp
 **Dockerfile**|https://github.com/awslabs/mcp/blob/main/src/aws-diagram-mcp-server/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/aws-diagram)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/aws-diagram --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/aws-documentation.md
+++ b/prompts/mcp/readmes/aws-documentation.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/awslabs/mcp
 **Dockerfile**|https://github.com/awslabs/mcp/blob/main/src/aws-documentation-mcp-server/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/aws-documentation)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/aws-documentation --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/aws-kb-retrieval-server.md
+++ b/prompts/mcp/readmes/aws-kb-retrieval-server.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/aws-kb-retrieval-server/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/aws-kb-retrieval-server)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/aws-kb-retrieval-server --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/azure.md
+++ b/prompts/mcp/readmes/azure.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Azure/azure-mcp
 **Dockerfile**|https://github.com/Azure/azure-mcp/blob/1ea702cb489ba95c5d9bea8d41fc18e9343703f8/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/azure)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/azure --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/bitrefill.md
+++ b/prompts/mcp/readmes/bitrefill.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/bitrefill/bitrefill-mcp-server
 **Dockerfile**|https://github.com/bitrefill/bitrefill-mcp-server/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/bitrefill)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/bitrefill --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/box.md
+++ b/prompts/mcp/readmes/box.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/box-community/mcp-server-box
 **Dockerfile**|https://github.com/box-community/mcp-server-box/blob/refs/pull/4/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/box)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/box --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/brave.md
+++ b/prompts/mcp/readmes/brave.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/brave-search/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/brave-search)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/brave-search --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/cdata-connectcloud.md
+++ b/prompts/mcp/readmes/cdata-connectcloud.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/CDataSoftware/connectcloud-mcp-server
 **Dockerfile**|https://github.com/CDataSoftware/connectcloud-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/cdata-connectcloud)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/cdata-connectcloud --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/chroma.md
+++ b/prompts/mcp/readmes/chroma.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/chroma-core/chroma-mcp
 **Dockerfile**|https://github.com/chroma-core/chroma-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/chroma)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/chroma --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/circleci.md
+++ b/prompts/mcp/readmes/circleci.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/CircleCI-Public/mcp-server-circleci
 **Dockerfile**|https://github.com/CircleCI-Public/mcp-server-circleci/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/circleci)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/circleci --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/context7.md
+++ b/prompts/mcp/readmes/context7.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/upstash/context7
 **Dockerfile**|https://github.com/upstash/context7/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/context7)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/context7 --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/cyreslab-ai-shodan.md
+++ b/prompts/mcp/readmes/cyreslab-ai-shodan.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Cyreslab-AI/shodan-mcp-server
 **Dockerfile**|https://github.com/Cyreslab-AI/shodan-mcp-server/blob/935f7044f60570cf2d094d94596eeea7872fb6be/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/cyreslab-ai-shodan)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/cyreslab-ai-shodan --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/dappier.md
+++ b/prompts/mcp/readmes/dappier.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/dappierai/dappier-mcp
 **Dockerfile**|https://github.com/dappierai/dappier-mcp/blob/staging/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/dappier)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/dappier --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/dart.md
+++ b/prompts/mcp/readmes/dart.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/its-dart/dart-mcp-server
 **Dockerfile**|https://github.com/its-dart/dart-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/dart)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/dart --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/databutton.md
+++ b/prompts/mcp/readmes/databutton.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/databutton/databutton-mcp
 **Dockerfile**|https://github.com/databutton/databutton-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/databutton)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/databutton --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/descope.md
+++ b/prompts/mcp/readmes/descope.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/descope-sample-apps/descope-mcp-server
 **Dockerfile**|https://github.com/descope-sample-apps/descope-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/descope)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/descope --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/desktop-commander.md
+++ b/prompts/mcp/readmes/desktop-commander.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/wonderwhy-er/DesktopCommanderMCP
 **Dockerfile**|https://github.com/wonderwhy-er/DesktopCommanderMCP/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/desktop-commander)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/desktop-commander --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/devhub-cms.md
+++ b/prompts/mcp/readmes/devhub-cms.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/devhub/devhub-cms-mcp
 **Dockerfile**|https://github.com/devhub/devhub-cms-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/devhub-cms)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/devhub-cms --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/duckduckgo.md
+++ b/prompts/mcp/readmes/duckduckgo.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/nickclyde/duckduckgo-mcp-server
 **Dockerfile**|https://github.com/nickclyde/duckduckgo-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/duckduckgo)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/duckduckgo --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/e2b.md
+++ b/prompts/mcp/readmes/e2b.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/e2b-dev/mcp-server
 **Dockerfile**|https://github.com/e2b-dev/mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/e2b)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/e2b --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/edubase.md
+++ b/prompts/mcp/readmes/edubase.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/EduBase/MCP
 **Dockerfile**|https://github.com/EduBase/MCP/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/edubase)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/edubase --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/elasticsearch.md
+++ b/prompts/mcp/readmes/elasticsearch.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/elastic/mcp-server-elasticsearch
 **Dockerfile**|https://github.com/elastic/mcp-server-elasticsearch/blob/refs/pull/37/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/elasticsearch)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/elasticsearch --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/elevenlabs.md
+++ b/prompts/mcp/readmes/elevenlabs.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/elevenlabs/elevenlabs-mcp
 **Dockerfile**|https://github.com/elevenlabs/elevenlabs-mcp/blob/refs/pull/17/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/elevenlabs)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/elevenlabs --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/everart.md
+++ b/prompts/mcp/readmes/everart.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/everart/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/everart)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/everart --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/exa.md
+++ b/prompts/mcp/readmes/exa.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/exa-labs/exa-mcp-server
 **Dockerfile**|https://github.com/exa-labs/exa-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/exa)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/exa --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/fetch.md
+++ b/prompts/mcp/readmes/fetch.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/fetch/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/fetch)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/fetch --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/fibery.md
+++ b/prompts/mcp/readmes/fibery.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Fibery-inc/fibery-mcp-server
 **Dockerfile**|https://github.com/Fibery-inc/fibery-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/fibery)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/fibery --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/filesystem.md
+++ b/prompts/mcp/readmes/filesystem.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/filesystem/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/filesystem)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/filesystem --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/firecrawl.md
+++ b/prompts/mcp/readmes/firecrawl.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/mendableai/firecrawl-mcp-server
 **Dockerfile**|https://github.com/mendableai/firecrawl-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/firecrawl)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/firecrawl --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/flexprice.md
+++ b/prompts/mcp/readmes/flexprice.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/flexprice/mcp-server
 **Dockerfile**|https://github.com/flexprice/mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/flexprice)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/flexprice --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/github-chat.md
+++ b/prompts/mcp/readmes/github-chat.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/AsyncFuncAI/github-chat-mcp
 **Dockerfile**|https://github.com/AsyncFuncAI/github-chat-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/github-chat)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/github-chat --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/github-official.md
+++ b/prompts/mcp/readmes/github-official.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/github/github-mcp-server
 **Dockerfile**|https://github.com/dgageot/github-mcp-server/blob/temp-fix/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/github-mcp-server)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/github-mcp-server --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/github.md
+++ b/prompts/mcp/readmes/github.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/github/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/github)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/github --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/gitlab.md
+++ b/prompts/mcp/readmes/gitlab.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/gitlab/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/gitlab)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/gitlab --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/glif.md
+++ b/prompts/mcp/readmes/glif.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/glifxyz/glif-mcp-server
 **Dockerfile**|https://github.com/glifxyz/glif-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/glif)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/glif --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/google-maps.md
+++ b/prompts/mcp/readmes/google-maps.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/google-maps/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/google-maps)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/google-maps --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/grafana.md
+++ b/prompts/mcp/readmes/grafana.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/grafana/mcp-grafana
 **Dockerfile**|https://github.com/grafana/mcp-grafana/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/grafana)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/grafana --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/gyazo.md
+++ b/prompts/mcp/readmes/gyazo.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/nota/gyazo-mcp-server
 **Dockerfile**|https://github.com/nota/gyazo-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/gyazo)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/gyazo --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/hackle.md
+++ b/prompts/mcp/readmes/hackle.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/hackle-io/hackle-mcp
 **Dockerfile**|https://github.com/hackle-io/hackle-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/hackle)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/hackle --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/handwriting-ocr.md
+++ b/prompts/mcp/readmes/handwriting-ocr.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Handwriting-OCR/handwriting-ocr-mcp-server
 **Dockerfile**|https://github.com/Handwriting-OCR/handwriting-ocr-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/handwriting-ocr)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/handwriting-ocr --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/heroku.md
+++ b/prompts/mcp/readmes/heroku.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/heroku/heroku-mcp-server
 **Dockerfile**|https://github.com/heroku/heroku-mcp-server/blob/refs/pull/24/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/heroku)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/heroku --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/husqvarna-automower.md
+++ b/prompts/mcp/readmes/husqvarna-automower.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/jeanlaurent/mcp-husqvarna-automower
 **Dockerfile**|https://github.com/jeanlaurent/mcp-husqvarna-automower/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/husqvarna-automower)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/husqvarna-automower --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/hyperbrowser.md
+++ b/prompts/mcp/readmes/hyperbrowser.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/hyperbrowserai/mcp
 **Dockerfile**|https://github.com/hyperbrowserai/mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/hyperbrowser)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/hyperbrowser --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/hyperspell.md
+++ b/prompts/mcp/readmes/hyperspell.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/hyperspell/hyperspell-mcp
 **Dockerfile**|https://github.com/hyperspell/hyperspell-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/hyperspell)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/hyperspell --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/iaptic.md
+++ b/prompts/mcp/readmes/iaptic.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/iaptic/mcp-server-iaptic
 **Dockerfile**|https://github.com/iaptic/mcp-server-iaptic/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/iaptic)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/iaptic --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/jetbrains.md
+++ b/prompts/mcp/readmes/jetbrains.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/GannaChernyshova/mcp-jetbrains
 **Dockerfile**|https://github.com/GannaChernyshova/mcp-jetbrains/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/jetbrains)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/jetbrains --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/kagisearch.md
+++ b/prompts/mcp/readmes/kagisearch.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/kagisearch/kagimcp
 **Dockerfile**|https://github.com/kagisearch/kagimcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/kagisearch)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/kagisearch --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/kong.md
+++ b/prompts/mcp/readmes/kong.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Kong/mcp-konnect
 **Dockerfile**|https://github.com/Kong/mcp-konnect/blob/refs/pull/7/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/kong)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/kong --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/kubernetes.md
+++ b/prompts/mcp/readmes/kubernetes.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Flux159/mcp-server-kubernetes
 **Dockerfile**|https://github.com/Flux159/mcp-server-kubernetes/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/kubernetes)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/kubernetes --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/lara.md
+++ b/prompts/mcp/readmes/lara.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/translated/lara-mcp
 **Dockerfile**|https://github.com/translated/lara-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/lara)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/lara --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/line.md
+++ b/prompts/mcp/readmes/line.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/line/line-bot-mcp-server
 **Dockerfile**|https://github.com/line/line-bot-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/line)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/line --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/mcp-discord.md
+++ b/prompts/mcp/readmes/mcp-discord.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/slimslenderslacks/mcp-discord
 **Dockerfile**|https://github.com/slimslenderslacks/mcp-discord/blob/slim/docker/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/mcp-discord)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/mcp-discord --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/memory.md
+++ b/prompts/mcp/readmes/memory.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/memory/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/memory)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/memory --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/mongodb.md
+++ b/prompts/mcp/readmes/mongodb.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/mongodb-js/mongodb-mcp-server
 **Dockerfile**|https://github.com/mongodb-js/mongodb-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/mongodb)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/mongodb --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/multiversx-mx.md
+++ b/prompts/mcp/readmes/multiversx-mx.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/multiversx/mx-mcp
 **Dockerfile**|https://github.com/multiversx/mx-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/multiversx-mx)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/multiversx-mx --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Other
 

--- a/prompts/mcp/readmes/neo4j-cloud-aura-api.md
+++ b/prompts/mcp/readmes/neo4j-cloud-aura-api.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/neo4j-contrib/mcp-neo4j
 **Dockerfile**|https://github.com/neo4j-contrib/mcp-neo4j/blob/main/servers/mcp-neo4j-cloud-aura-api/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/neo4j-cloud-aura-api)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/neo4j-cloud-aura-api --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/neo4j-cypher.md
+++ b/prompts/mcp/readmes/neo4j-cypher.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/neo4j-contrib/mcp-neo4j
 **Dockerfile**|https://github.com/neo4j-contrib/mcp-neo4j/blob/main/servers/mcp-neo4j-cypher/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/neo4j-cypher)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/neo4j-cypher --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/neo4j-memory.md
+++ b/prompts/mcp/readmes/neo4j-memory.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/neo4j-contrib/mcp-neo4j
 **Dockerfile**|https://github.com/neo4j-contrib/mcp-neo4j/blob/main/servers/mcp-neo4j-memory/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/neo4j-memory)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/neo4j-memory --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/neon.md
+++ b/prompts/mcp/readmes/neon.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/neondatabase-labs/mcp-server-neon
 **Dockerfile**|https://github.com/neondatabase-labs/mcp-server-neon/blob/dbfa184afd9fc677c0d6b007a62b33194e883821/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/neon)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/neon --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/node-code-sandbox.md
+++ b/prompts/mcp/readmes/node-code-sandbox.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/alfonsograziano/node-code-sandbox-mcp
 **Dockerfile**|https://github.com/alfonsograziano/node-code-sandbox-mcp/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/node-code-sandbox)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/node-code-sandbox --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/notion.md
+++ b/prompts/mcp/readmes/notion.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/makenotion/notion-mcp-server
 **Dockerfile**|https://github.com/makenotion/notion-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/notion)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/notion --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/obsidian.md
+++ b/prompts/mcp/readmes/obsidian.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/MarkusPfundstein/mcp-obsidian
 **Dockerfile**|https://github.com/docker/mcp-obsidian/blob/docker-support/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/obsidian)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/obsidian --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/openapi-schema.md
+++ b/prompts/mcp/readmes/openapi-schema.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/hannesj/mcp-openapi-schema
 **Dockerfile**|https://github.com/slimslenderslacks/mcp-openapi-schema/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/openapi-schema)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/openapi-schema --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/opik.md
+++ b/prompts/mcp/readmes/opik.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/comet-ml/opik-mcp
 **Dockerfile**|https://github.com/comet-ml/opik-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/opik)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/opik --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/osp_marketing_tools.md
+++ b/prompts/mcp/readmes/osp_marketing_tools.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/open-strategy-partners/osp_marketing_tools
 **Dockerfile**|https://github.com/open-strategy-partners/osp_marketing_tools/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/osp_marketing_tools)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/osp_marketing_tools --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Creative Commons Attribution Share Alike 4.0 International
 

--- a/prompts/mcp/readmes/oxylabs.md
+++ b/prompts/mcp/readmes/oxylabs.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/oxylabs/oxylabs-mcp
 **Dockerfile**|https://github.com/oxylabs/oxylabs-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/oxylabs)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/oxylabs --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/perplexity-ask.md
+++ b/prompts/mcp/readmes/perplexity-ask.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/ppl-ai/modelcontextprotocol
 **Dockerfile**|https://github.com/ppl-ai/modelcontextprotocol/blob/f0a927c250e04b389ff5c34f6a2a85ad625668e8/perplexity-ask/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/perplexity-ask)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/perplexity-ask --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/playwright.md
+++ b/prompts/mcp/readmes/playwright.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/microsoft/playwright-mcp
 **Dockerfile**|https://github.com/microsoft/playwright-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/playwright)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/playwright --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/postgres.md
+++ b/prompts/mcp/readmes/postgres.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/postgres/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/postgres)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/postgres --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/pulumi.md
+++ b/prompts/mcp/readmes/pulumi.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/pulumi/mcp-server
 **Dockerfile**|https://github.com/pulumi/mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/pulumi)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/pulumi --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/puppeteer.md
+++ b/prompts/mcp/readmes/puppeteer.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/puppeteer/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/puppeteer)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/puppeteer --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/razorpay.md
+++ b/prompts/mcp/readmes/razorpay.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/razorpay/razorpay-mcp-server
 **Dockerfile**|https://github.com/razorpay/razorpay-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/razorpay)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/razorpay --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/redis-cloud.md
+++ b/prompts/mcp/readmes/redis-cloud.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/redis/mcp-redis-cloud
 **Dockerfile**|https://github.com/redis/mcp-redis-cloud/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/redis-cloud)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/redis-cloud --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/redis.md
+++ b/prompts/mcp/readmes/redis.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/redis/mcp-redis
 **Dockerfile**|https://github.com/redis/mcp-redis/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/redis)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/redis --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/resend.md
+++ b/prompts/mcp/readmes/resend.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/resend/mcp-send-email
 **Dockerfile**|https://github.com/slimslenderslacks/mcp-send-email/blob/slim/docker/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/resend)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/resend --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/risken.md
+++ b/prompts/mcp/readmes/risken.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/ca-risken/risken-mcp-server
 **Dockerfile**|https://github.com/ca-risken/risken-mcp-server/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/risken)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/risken --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/scrapegraph.md
+++ b/prompts/mcp/readmes/scrapegraph.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/ScrapeGraphAI/scrapegraph-mcp
 **Dockerfile**|https://github.com/ScrapeGraphAI/scrapegraph-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/scrapegraph)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/scrapegraph --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/scrapezy.md
+++ b/prompts/mcp/readmes/scrapezy.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Scrapezy/mcp
 **Dockerfile**|https://github.com/Scrapezy/mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/scrapezy)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/scrapezy --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/sentry.md
+++ b/prompts/mcp/readmes/sentry.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/sentry/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/sentry)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/sentry --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/sequentialthinking.md
+++ b/prompts/mcp/readmes/sequentialthinking.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/sequentialthinking/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/sequentialthinking)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/sequentialthinking --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/shopify.md
+++ b/prompts/mcp/readmes/shopify.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Shopify/dev-mcp
 **Dockerfile**|https://github.com/Shopify/dev-mcp/blob/refs/pull/7/merge/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/shopify)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/shopify --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|ISC License
 

--- a/prompts/mcp/readmes/slack.md
+++ b/prompts/mcp/readmes/slack.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/slack/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/slack)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/slack --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/smithery-cli.md
+++ b/prompts/mcp/readmes/smithery-cli.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/smithery-ai/smithery-cli-mcp
 **Dockerfile**|https://github.com/smithery-ai/smithery-cli-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/smithery-cli)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/smithery-cli --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|GNU General Public License v3.0
 

--- a/prompts/mcp/readmes/sqlite.md
+++ b/prompts/mcp/readmes/sqlite.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/sqlite/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/sqlite)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/sqlite --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/stripe.md
+++ b/prompts/mcp/readmes/stripe.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/stripe/agent-toolkit
 **Dockerfile**|https://github.com/stripe/agent-toolkit/blob/main/modelcontextprotocol/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/stripe)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/stripe --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/tavily.md
+++ b/prompts/mcp/readmes/tavily.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/tavily-ai/tavily-mcp
 **Dockerfile**|https://github.com/tavily-ai/tavily-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/tavily)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/tavily --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/tembo.md
+++ b/prompts/mcp/readmes/tembo.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/tembo-io/mcp-server-tembo
 **Dockerfile**|https://github.com/tembo-io/mcp-server-tembo/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/tembo)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/tembo --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/time.md
+++ b/prompts/mcp/readmes/time.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/modelcontextprotocol/servers
 **Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.6/src/time/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/time)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/time --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/triplewhale.md
+++ b/prompts/mcp/readmes/triplewhale.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Triple-Whale/mcp-server-triplewhale
 **Dockerfile**|https://github.com/Triple-Whale/mcp-server-triplewhale/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/triplewhale)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/triplewhale --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/tweetbinder.md
+++ b/prompts/mcp/readmes/tweetbinder.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/audienseco/mcp-tweetbinder
 **Dockerfile**|https://github.com/audienseco/mcp-tweetbinder/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/tweetbinder)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/tweetbinder --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|Apache License 2.0
 

--- a/prompts/mcp/readmes/veyrax.md
+++ b/prompts/mcp/readmes/veyrax.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/VeyraX/veyrax-mcp
 **Dockerfile**|https://github.com/VeyraX/veyrax-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/veyrax)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/veyrax --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|
 

--- a/prompts/mcp/readmes/webflow.md
+++ b/prompts/mcp/readmes/webflow.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/webflow/mcp-server
 **Dockerfile**|https://github.com/slimslenderslacks/mcp-server/blob/slim/docker/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/webflow)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/webflow --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/wikipedia-mcp.md
+++ b/prompts/mcp/readmes/wikipedia-mcp.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/Rudra-ravi/wikipedia-mcp
 **Dockerfile**|https://github.com/Rudra-ravi/wikipedia-mcp/blob/main/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/wikipedia-mcp)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/wikipedia-mcp --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/wolfram-alpha.md
+++ b/prompts/mcp/readmes/wolfram-alpha.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/SecretiveShell/MCP-wolfram-alpha
 **Dockerfile**|https://github.com/SecretiveShell/MCP-wolfram-alpha/blob/master/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/wolfram-alpha)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/wolfram-alpha --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 

--- a/prompts/mcp/readmes/youtube_transcript.md
+++ b/prompts/mcp/readmes/youtube_transcript.md
@@ -13,7 +13,6 @@ Attribute|Details|
 **Repository**|https://github.com/jkawamoto/mcp-youtube-transcript
 **Dockerfile**|https://github.com/slimslenderslacks/mcp-youtube-transcript/blob/slim/docker/Dockerfile
 **Docker Image built by**|Docker Inc.
-**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/youtube-transcript)
 **Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/youtube-transcript --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
 **Licence**|MIT License
 


### PR DESCRIPTION
## Summary
Poliwrath's org-image-score backend is being decommissioned as part of [DXT-1149](https://docker.atlassian.net/browse/DXT-1149). This badge line has been carried over into every generated readme under `prompts/mcp/readmes/` and will render stale (or break) once the underlying computation is fully retired, so it's removed here for parity with the same cleanup happening in `docker/ai-mcp`.

## Context
Austin Berry from the AI Tools MCP Catalog team confirmed in [this Slack thread](https://docker.slack.com/archives/C08J27QSJJJ/p1784913809144049) that it's safe to drop the badge line, and suggested removing it from this repo as well for parity since it carries the same pattern.

## Test plan
- [ ] Confirm no other content in this repo still links to the `org-image-score` badge route
- [ ] Confirm generated readmes still render correctly in whatever consumes `prompts/mcp/readmes/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DXT-1149]: https://docker.atlassian.net/browse/DXT-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ